### PR TITLE
Implement ROOTPIVOT

### DIFF
--- a/src/libprison/libprison.h
+++ b/src/libprison/libprison.h
@@ -84,6 +84,10 @@ struct prison_console_connect {
 	char					p_term[64];
 };
 
+struct build_step_root_pivot {
+	char					sr_dir[MAXPATHLEN];
+};
+
 /*
  * Data structures to facilitate image builds, shared between the client
  * and daemon processs.
@@ -120,6 +124,7 @@ struct build_step {
 #define	STEP_RUN	3
 #define	STEP_WORKDIR	4
 #define	STEP_COPY_FROM	5
+#define	STEP_ROOT_PIVOT	6
 	TAILQ_ENTRY(build_step)	step_glue;
 	union {
 		/*
@@ -132,6 +137,7 @@ struct build_step {
 		struct build_step_add		 step_add;
 		struct build_step_workdir	 step_workdir;
 		struct build_step_copy_from	 step_copy_from;
+		struct build_step_root_pivot	 step_root_pivot;
 	} step_data;
 	char					 step_string[1024];
 };

--- a/src/prison/grammar.y
+++ b/src/prison/grammar.y
@@ -341,6 +341,34 @@ op_spec:
 		b_step->step_op = STEP_COPY;
 		cur_build_step = b_step;
 	} copy_spec
+	| ROOTPIVOT
+	{
+		struct build_step *b_step;
+
+		b_step = calloc(1, sizeof(*b_step));
+		if (b_step == NULL) {
+			err(1, "calloc(build step) faild");
+		}
+		b_step->step_op = STEP_ROOT_PIVOT;
+		cur_build_step = b_step;
+	}
+	STRING
+	{
+		struct build_step *b_step;
+		struct build_stage *bsp;
+
+		b_step = cur_build_step;
+		bsp = cur_build_stage;
+		assert(b_step != NULL);
+		assert(bsp != NULL);
+		strlcpy(b_step->step_data.step_root_pivot.sr_dir,
+                    $3, sizeof(b_step->step_data.step_root_pivot.sr_dir));
+		cur_build_step->stage_index = stage_counter;
+		snprintf(b_step->step_string, sizeof(b_step->step_string),
+		    "ROOTPIVOT %s", $3);
+		TAILQ_INSERT_HEAD(&bsp->step_head, b_step, step_glue);
+		cur_build_step = NULL;
+	}
 	| WORKDIR
 	{
 		struct build_step *b_step;
@@ -351,7 +379,6 @@ op_spec:
 		}
 		b_step->step_op = STEP_WORKDIR;
 		cur_build_step = b_step;
-
 	}
 	STRING
 	{
@@ -365,6 +392,8 @@ op_spec:
 		strlcpy(b_step->step_data.step_workdir.sw_dir,
 		    $3, sizeof(b_step->step_data.step_workdir.sw_dir));
 		cur_build_step->stage_index = stage_counter;
+		snprintf(b_step->step_string, sizeof(b_step->step_string),
+		    "WORKDIR %s", $3);
 		TAILQ_INSERT_HEAD(&bsp->step_head, b_step, step_glue);
 		cur_build_step = NULL;
 	}

--- a/src/prison/token.l
+++ b/src/prison/token.l
@@ -54,6 +54,7 @@ ADD		return (ADD);
 COPY		return (COPY);
 WORKDIR		return (WORKDIR);
 ENTRYPOINT	return (ENTRYPOINT);
+ROOTPIVOT	return (ROOTPIVOT);
 CMD		return (CMD);
 {integer}       {
                         yylval.num = atoi(yytext);

--- a/src/prisond/build.c
+++ b/src/prisond/build.c
@@ -167,6 +167,10 @@ build_emit_shell_script(struct build_context *bcp, int stage_index)
 		fprintf(fp, "echo \"-- Step %d/%d : %s\"\n",
 		    ++taken, steps, bsp->step_string);
 		switch (bsp->step_op) {
+		case STEP_ROOT_PIVOT:
+			fprintf(fp, "ln -s %s /cellblock-root-ptr\n",
+			    bsp->step_data.step_root_pivot.sr_dir);
+			break;
 		case STEP_ADD:
 			build_emit_add_instruction(bsp, fp);
 			break;

--- a/src/prisond/shell/commit_script.sh
+++ b/src/prisond/shell/commit_script.sh
@@ -11,9 +11,27 @@ n_stages=$5
 
 commit_image()
 {
-    rm -fr "${build_root}/${build_index}/tmp"
-    mkdir "${build_root}/${build_index}/tmp"
-    tar -C "${build_root}/${build_index}" --exclude="/tmp" \
+    if [ -h "${build_root}/${build_index}/root/cellblock-root-ptr" ]; then
+        dir=`readlink "${build_root}/${build_index}/root/cellblock-root-ptr"`
+        src="${build_root}/${build_index}/root/${dir}"
+        #
+        # If we have root pivoting step, make sure we copy the entry point
+        # and entry point args from the original root.
+        #
+        if [ -f "${build_root}/${build_index}/ENTRYPOINT" ]; then
+            cp "${build_root}/${build_index}/ENTRYPOINT" \
+                "${build_root}/${build_index}/root/${dir}"
+        fi
+        if [ -f "${build_root}/${build_index}/ARGS" ]; then
+            cp "${build_root}/${build_index}/ARGS" \
+                "${build_root}/${build_index}/root/${dir}"
+        fi
+    else
+        rm -fr "${build_root}/${build_index}/root/tmp/*"
+        src="${build_root}/${build_index}"
+    fi
+    ls -l "${src}"
+    tar -C "${src}" --exclude="/tmp" \
       --exclude="/dev" \
       -cf "${data_dir}/images/${image_name}.tar.gz" .
     if [ -d "${data_dir}/images/${image_name}" ]; then


### PR DESCRIPTION
This is a cellblock specific build step that instructs the bundler
to create the image from an alternate root. This is useful when
building images from source without all the build cruft.

For example:

```
FROM base
  RUN "pkg --yes update"
  RUN "pkg install --yes git"
  RUN "git clone --depth 1 -b stable/12 https://github.com/freebsd/freebsd.git /code"
  RUN "mkdir -p /DESTDIR/root"
  WORKDIR /code
  RUN "make -j4 buildworld"
  RUN "make installworld DESTDIR=/DESTDIR/root"
  WORKDIR /code/etc
  RUN "make distribution DESTDIR=/DESTDIR/root"
  ROOTPIVOT /DESTDIR

ENTRYPOINT ["/bin/tcsh"]
```