### PR TITLE
Fix the build with -fno-common

### DIFF
--- a/src/cblock/build.c
+++ b/src/cblock/build.c
@@ -75,6 +75,7 @@ build_manifest_load(struct build_config *bcp)
 {
 	struct build_manifest *bmp;
 	char manifest_path[128];
+	extern char *yyfile;
 	FILE *f;
 
 	bmp = build_manifest_init();

--- a/src/cblock/main.c
+++ b/src/cblock/main.c
@@ -50,6 +50,8 @@
 #include "main.h"
 #include "sock_ipc.h"
 
+struct global_params gcfg;
+
 struct sub_command {
 	char		*sc_name;
 	int		(*sc_callback)(int, char **, int);

--- a/src/cblock/main.h
+++ b/src/cblock/main.h
@@ -36,8 +36,6 @@ struct global_params {
 	int		 c_family;
 };
 
-struct global_params gcfg;
-
 void		reset_getopt_state(void);
 int		console_main(int, char **, int);
 int		launch_main(int, char **, int);

--- a/src/cblock/parser.h
+++ b/src/cblock/parser.h
@@ -28,10 +28,9 @@
 #define PARSER_DOT_H_
 
 extern int	 yyparse(void);
-extern int      yylex(void);
-void            yyerror(const char *);
-char		*yyfile;
-extern FILE		*yyin;
+extern int       yylex(void);
+void             yyerror(const char *);
+extern FILE	*yyin;
 
 
 struct build_manifest 	*build_manifest_init(void);

--- a/src/cblock/token.l
+++ b/src/cblock/token.l
@@ -118,6 +118,8 @@ CMD		return (CMD);
                 }
 %%
 
+char *yyfile;
+
 void
 yyerror(const char *str)
 {

--- a/src/cblockd/build.c
+++ b/src/cblockd/build.c
@@ -166,6 +166,7 @@ static int
 build_stage_compile_copy_from(struct build_context *bcp, int stage_index)
 {
 	char tar_path[MAXPATHLEN], root_path[MAXPATHLEN], *src, **argv;
+	extern struct global_params gcfg;
 	build_copy_from_t stage_deps;
 	struct build_copy_from *cfp;
 	int k, this_stage, status;
@@ -318,6 +319,7 @@ static int
 build_init_stage(struct build_context *bcp, struct build_stage *stage)
 {
 	char script[128], index[16], context_archive[128], **argv;
+	extern struct global_params gcfg;
 	vec_t *vec, *vec_env;
 	int status;
 	pid_t pid;
@@ -378,6 +380,7 @@ static int
 build_commit_image(struct build_context *bcp)
 {
 	char commit_cmd[128], **argv, s_index[32], nstages[32];
+	extern struct global_params gcfg;
 	char path[1024], *do_fim, buf[64];
 	struct build_stage *bsp;
 	int status, k, last;
@@ -469,6 +472,7 @@ static int
 build_run_build_stage(struct build_context *bcp)
 {
 	char stage_root[MAXPATHLEN], **argv, builder[1024], buf[512];
+	extern struct global_params gcfg;
 	struct build_stage *bstg;
 	vec_t *vec, *vec_env;
 	int status, k;
@@ -576,6 +580,7 @@ static int
 dispatch_build_set_outfile(struct build_context *bcp,
     char *ebuf, size_t len)
 {
+	extern struct global_params gcfg;
 	char path[512], build_root[512];
 	int fd;
 

--- a/src/cblockd/cblock.c
+++ b/src/cblockd/cblock.c
@@ -60,10 +60,15 @@
 #include <cblock/libcblock.h>
 
 static int reap_children;
+cblock_peer_head_t p_head;
+cblock_instance_head_t pr_head;
+pthread_mutex_t peer_mutex;
+pthread_mutex_t cblock_mutex;
 
 int
 cblock_create_pid_file(struct cblock_instance *p)
 {
+	extern struct global_params gcfg;
 	char pid_path[1024], pid_buf[32];
 	mode_t mode;
 	int flags;
@@ -153,6 +158,7 @@ cblock_instance_match(char *full_instance_name, const char *user_supplied)
 void
 cblock_fork_cleanup(char *instance, char *type, int dup_sock, int verbose)
 {
+	extern struct global_params gcfg;
         char buf[128], **argv;
         vec_t *vec, *vec_env;
         int status;
@@ -193,6 +199,7 @@ cblock_fork_cleanup(char *instance, char *type, int dup_sock, int verbose)
 void
 cblock_remove(struct cblock_instance *pi)
 {
+	extern struct global_params gcfg;
 	uint32_t cmd;
 	size_t cur;
 

--- a/src/cblockd/cblock.h
+++ b/src/cblockd/cblock.h
@@ -16,7 +16,4 @@ struct cblock_instance *
 void *		cblock_handle_request(void *);
 void *		cblock_handle_request(void *);
 
-cblock_peer_head_t p_head;
-cblock_instance_head_t pr_head;
-
-#endif
+#endif	/* CBLOCK_DOT_H_ */

--- a/src/cblockd/dispatch.c
+++ b/src/cblockd/dispatch.c
@@ -71,6 +71,8 @@ handle_reap_children(int sig)
 static int
 tty_initialize_fdset(fd_set *rfds)
 {
+	extern cblock_instance_head_t pr_head;
+	extern pthread_mutex_t cblock_mutex;
 	struct cblock_instance *pi, *p_temp;
 	int maxfd;
 
@@ -93,6 +95,8 @@ tty_initialize_fdset(fd_set *rfds)
 void *
 tty_io_queue_loop(void *arg)
 {
+	extern cblock_instance_head_t pr_head;
+	extern pthread_mutex_t cblock_mutex;
 	struct cblock_instance *pi;
 	struct timeval tv;
 	u_char buf[8192];
@@ -149,6 +153,7 @@ tty_io_queue_loop(void *arg)
 int
 dispatch_connect_console(int sock)
 {
+	extern pthread_mutex_t cblock_mutex;
 	struct cblock_console_connect pcc;
 	struct cblock_response resp;
 	struct cblock_instance *pi;
@@ -208,6 +213,8 @@ dispatch_connect_console(int sock)
 int
 dispatch_launch_cblock(int sock)
 {
+	extern cblock_instance_head_t pr_head;
+	extern pthread_mutex_t cblock_mutex;
 	extern struct global_params gcfg;
 	char **env, **argv, buf[128];
 	struct cblock_response resp;
@@ -287,6 +294,8 @@ dispatch_launch_cblock(int sock)
 void *
 dispatch_work(void *arg)
 {
+	extern pthread_mutex_t peer_mutex;
+	extern cblock_peer_head_t p_head;
 	struct cblock_peer *p;
 	uint32_t cmd;
 	ssize_t cc;

--- a/src/cblockd/dispatch.h
+++ b/src/cblockd/dispatch.h
@@ -61,9 +61,4 @@ void		gen_sha256_string(unsigned char *, char *);
 char *		gen_sha256_instance_id(char *);
 void *		dispatch_work(void *);
 
-cblock_peer_head_t p_head;
-cblock_instance_head_t pr_head;
-pthread_mutex_t peer_mutex;
-pthread_mutex_t cblock_mutex;
-
 #endif

--- a/src/cblockd/exec.c
+++ b/src/cblockd/exec.c
@@ -76,6 +76,7 @@ int
 dispatch_generic_command(int sock)
 {
 	struct cblock_generic_command arg;
+	extern struct global_params gcfg;
 	char *marshalled,*script;
 	int pipefds[2], error;
 	ssize_t cc;

--- a/src/cblockd/main.c
+++ b/src/cblockd/main.c
@@ -55,6 +55,8 @@
 
 #include <cblock/libcblock.h>
 
+struct global_params gcfg;
+
 static char *banner =
 	"            __ __ __    __            __\n" \
 	".----.-----|  |  |  |--|  .-----.----|  |--.-----.\n" \

--- a/src/cblockd/main.h
+++ b/src/cblockd/main.h
@@ -48,6 +48,4 @@ struct global_params {
 	char		*c_forge_path;
 };
 
-struct global_params gcfg;
-
 #endif

--- a/src/cblockd/sock_ipc.c
+++ b/src/cblockd/sock_ipc.c
@@ -146,6 +146,7 @@ sock_ipc_setup_inet(struct global_params *cmd)
 static int
 sock_ipc_accept_connection(int sock)
 {
+	extern struct global_params gcfg;
 	struct sockaddr_storage addrs;
 	struct cblock_peer *p;
 	struct sockaddr sa;


### PR DESCRIPTION
The default behavior of the compiler changed in LLVM11 and GCC10 and
will generate errors if we attempt to place duplicate definitions of
a symbol into the common section (the old default behavior was to allow
this but merge them into common entry)