### PR TITLE
Build images in jails and introduce OS release

### DIFF
--- a/examples/base/Cblockfile
+++ b/examples/base/Cblockfile
@@ -1,8 +1,9 @@
 FROM forge:latest
-   ADD resolv.conf /etc
-   RUN "mkdir -p imgbuild/root"
-   ENV "SSL_CA_CERT_FILE" = "/etc/ca-root-nss.crt"
-   ADD https://download.freebsd.org/ftp/releases/amd64/12.1-RELEASE/base.txz imgbuild/root
-   ROOTPIVOT imgbuild
 
+RUN "mkdir -p imgbuild/root"
+ENV "SSL_CA_CERT_FILE" = "/etc/ca-root-nss.crt"
+ADD https://download.freebsd.org/ftp/releases/amd64/12.1-RELEASE/base.txz imgbuild/root
+ROOTPIVOT imgbuild
+
+OSRELEASE 12.1-RELEASE
 ENTRYPOINT [ "/bin/tcsh" ]

--- a/examples/builder/Cblockfile
+++ b/examples/builder/Cblockfile
@@ -1,5 +1,6 @@
-FROM base:12.1-RELEASE
+FROM freebsd
   ADD resolv.conf /etc
+  ENV "IGNORE_OSVERSION" = "TRUE"
   RUN "pkg --yes update"
   RUN "pkg install --yes git"
   RUN "pkg install --yes gcc llvm flex bison cmake"

--- a/src/cblock/build.c
+++ b/src/cblock/build.c
@@ -180,6 +180,11 @@ build_send_context(int sock, struct build_config *bcp)
 	strlcpy(pbc.p_image_name, bcp->b_name, sizeof(pbc.p_image_name));
 	strlcpy(pbc.p_cblock_file, bcp->b_cblock_file,
 	    sizeof(pbc.p_cblock_file));
+	if (bcp->b_bmp->osrelease) {
+		printf("coying OS release\n");
+		strlcpy(pbc.p_os_release, bcp->b_bmp->osrelease,
+		    sizeof(pbc.p_os_release));
+	}
 	if (bcp->b_bmp->entry_point) {
 		strlcpy(pbc.p_entry_point, bcp->b_bmp->entry_point,
 		    sizeof(pbc.p_entry_point));

--- a/src/cblock/grammar.y
+++ b/src/cblock/grammar.y
@@ -65,7 +65,7 @@ static char *archive_extensions[] = {
 
 %token FROM AS COPY ADD RUN ENTRYPOINT STRING WORKDIR
 %token OPEN_SQUARE_BRACKET CLOSE_SQUARE_BRACKET COPY_FROM ENV EQ
-%token INTEGER COMMA CMD ROOTPIVOT
+%token INTEGER COMMA CMD ROOTPIVOT OSRELEASE
 
 %type <num> INTEGER
 %type <c_string> STRING
@@ -152,6 +152,19 @@ entry_def:
 		free(cmd_string);
 		vec_free(vec);
 		vec = NULL;
+        }
+	| OSRELEASE STRING
+	{
+		struct build_manifest *bmp;
+
+		bmp = get_current_build_manifest();
+		if (bmp->osrelease != NULL) {
+			errx(1, "OSRELEASE: has already been specified");
+		}
+		bmp->osrelease = strdup($2);
+		if (bmp->osrelease == NULL) {
+			err(1, "failed to dup os release");
+		}
         }
         ;
 

--- a/src/cblock/image.c
+++ b/src/cblock/image.c
@@ -63,6 +63,20 @@ image_usage(void)
 }
 
 static void
+image_prune(struct image_config *icp, int ctlsock)
+{
+	struct cblock_generic_command arg;
+	uint32_t cmd;
+
+	cmd = PRISON_IPC_GENERIC_COMMAND;
+	bzero(&arg, sizeof(arg));
+	sock_ipc_must_write(ctlsock, &cmd, sizeof(cmd));
+	sprintf(arg.p_cmdname, "instance_prune");
+	sock_ipc_must_write(ctlsock, &arg, sizeof(arg));
+	sock_ipc_from_sock_to_tty(ctlsock);
+}
+
+static void
 image_get(struct image_config *icp, int ctlsock)
 {
 	struct cblock_generic_command arg;
@@ -105,6 +119,10 @@ image_main(int argc, char *argv [], int ctlsock)
 	}
 	argc -= optind;
 	argv += optind;
+	if (ic.i_do_prune) {
+		image_prune(&ic, ctlsock);
+		return (0);
+	}
 	image_get(&ic, ctlsock);
 	return (0);
 }

--- a/src/cblock/token.l
+++ b/src/cblock/token.l
@@ -52,6 +52,7 @@ AS		return (AS);
 RUN		return (RUN);
 ADD		return (ADD);
 COPY		return (COPY);
+OSRELEASE	return (OSRELEASE);
 ENV		return (ENV);
 WORKDIR		return (WORKDIR);
 ENTRYPOINT	return (ENTRYPOINT);

--- a/src/cblockd/build.c
+++ b/src/cblockd/build.c
@@ -398,6 +398,20 @@ build_commit_image(struct build_context *bcp)
 		break;
 	}
 	/*
+	 * Write out the OS release specification for the container if there is
+	 * one. If not, the default OS of the host environment will be used.
+	 */
+	if (bcp->pbc.p_os_release[0] != '\0') {
+		snprintf(path, sizeof(path), "%s/%d/OSRELEASE",
+		    bcp->build_root, last);
+		fp = fopen(path, "w+");
+		if (fp == NULL) {
+			err(1, "fopen(%s) failed", path);
+		}
+		fprintf(fp, "%s", bcp->pbc.p_os_release);
+		fclose(fp);
+	}
+	/*
 	 * Write out entry point and enty point args (CMD) for the final stage
 	 */
 	if (bcp->pbc.p_entry_point[0] != '\0') {
@@ -552,6 +566,8 @@ build_run_build_stage(struct build_context *bcp)
 			}
 			vec_append(vec, builder);
 			vec_append(vec, stage_root);
+			vec_append(vec, bcp->instance);
+			vec_append(vec, bcp->pbc.p_os_release);
 			vec_finalize(vec);
 			argv = vec_return(vec);
 			execve(*argv, argv, vec_return(vec_env));

--- a/src/include/cblock/libcblock.h
+++ b/src/include/cblock/libcblock.h
@@ -92,6 +92,7 @@ struct cblock_build_context {
 	char					p_entry_point_args[MAXPATHLEN];
 	int					p_verbose;
 	int					p_build_fim_spec;
+	char					p_os_release[MAXPATHLEN];
 };
 
 struct cblock_response {
@@ -198,6 +199,7 @@ struct build_manifest {
 	char					*entry_point;
 	char					*entry_point_args;
 	char					*maintainr;
+	char					*osrelease;
 };
 
 struct build_context {

--- a/src/shell/stage_commit.sh
+++ b/src/shell/stage_commit.sh
@@ -46,6 +46,15 @@ commit_image()
         dir=$(readlink "${build_root}/${build_index}/root/cellblock-root-ptr")
         src="${build_root}/${build_index}/root/${dir}"
         #
+        # If the container is expecting a specific OS release to be specified
+        # for package installs or whatever else, copy that over into the
+        # the image so the dispatcher and set it properly
+        #
+        if [ -f "${build_root}/${build_index}/OSRELEASE" ]; then
+            cp "${build_root}/${build_index}/OSRELEASE" \
+                "${build_root}/${build_index}/root/${dir}"
+        fi
+        #
         # If we have root pivoting step, make sure we copy the entry point
         # and entry point args from the original root.
         #

--- a/src/shell/stage_launch.sh
+++ b/src/shell/stage_launch.sh
@@ -24,8 +24,6 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 #
-set -x
-
 data_root="$1"
 image_name="$2"
 instance_id="$3"
@@ -208,6 +206,15 @@ config_devfs()
     fi
 }
 
+emit_os_release()
+{
+    if [ -f "${image_dir}/OSRELEASE" ]; then
+        cat "${image_dir}/OSRELEASE"
+    else
+        uname -r
+    fi
+}
+
 emit_entrypoint()
 {
     CMD=`cat "${image_dir}/ENTRYPOINT"`
@@ -372,7 +379,7 @@ do_launch()
           "vnet" \
           "vnet.interface=$netif" \
           "name=${instance_id}" \
-          "osrelease=12.1-RELEASE" \
+          "osrelease=$(emit_os_release)" \
           "path=${instance_root}" \
           command="$@"
     else
@@ -385,7 +392,7 @@ do_launch()
           "host.hostname=${instance_hostname}" \
           "ip4.addr=${ip4}" \
           "name=${instance_id}" \
-          "osrelease=12.1-RELEASE" \
+          "osrelease=$(emit_os_release)" \
           "path=${instance_root}" \
           command="$@"
     fi


### PR DESCRIPTION
- Introduce OS release so that image building operations and  pull
  images from whichever desired OS version is needed. This is added
  to the Cblockfile and will also be used when launching the jail
- Instead of building in chroot, build within a jail. Not only is this
  more secure when building potentially untrusted Cblockfiles, it also
  gives us the luxary of being able to specify target os versions to
  pull packages for
- Rather than require users supply their own resolv.conf, inject the
  one present in the host environment. Users can include their own
  resolv.conf files if they choose witin the build directory which
  will override whatever was in the host environment
- Cleanup example Cblockfiles and remove resolv.conf
- Add basic support for pruning old, un-referenced images. Those are
  images that do not currently have any tags
- Fix a few minor crashes when strings are present where expected