### PR TITLE
Re-enable output translation OPOST

### DIFF
--- a/src/cblock/console.c
+++ b/src/cblock/console.c
@@ -120,7 +120,6 @@ console_tty_set_raw_mode(int fd)
 	tbuf.c_iflag &= ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON);
 	tbuf.c_cflag &= ~(CSIZE | PARENB);
 	tbuf.c_cflag |= CS8;
-	tbuf.c_oflag &= ~(OPOST);
 	tbuf.c_cc[VMIN] = 1;
 	tbuf.c_cc[VTIME] = 0;
 	if (tcsetattr(fd, TCSAFLUSH, &tbuf) == -1) {


### PR DESCRIPTION
The last commit accidently disabled output translation. Do not disable this, we need it otherwise things do not render properly for some processes.