### PR TITLE
Fix several bugs found during code review

### DIFF
--- a/src/cblockd/build.c
+++ b/src/cblockd/build.c
@@ -76,7 +76,7 @@ waitpid_ignore_intr(pid_t pid, int *status)
 		rpid = waitpid(pid, status, 0);
 		if (rpid == -1 && errno == EINTR) {
 			continue;
-		} else if (pid == -1) {
+		} else if (rpid == -1) {
 			err(1, "waitpid failed");
 		}
 		break;
@@ -123,7 +123,7 @@ static char *
 build_get_stage_deps(struct build_context *bcp, int stage_index)
 {
 	struct build_step *step;
-	char retbuf[256], *p;
+	char retbuf[256], tmp[32], *p;
 	int k, j;
 
 	bzero(retbuf, sizeof(retbuf));
@@ -141,7 +141,8 @@ build_get_stage_deps(struct build_context *bcp, int stage_index)
 		 * and fix it so that it's not using a statically
 		 * sized stack buffer.
 		 */
-		sprintf(retbuf, "%s %d", retbuf, j);
+		snprintf(tmp, sizeof(tmp), " %d", j);
+		strlcat(retbuf, tmp, sizeof(retbuf));
 	}
 	p = retbuf;
 	/*

--- a/src/cblockd/cblock.c
+++ b/src/cblockd/cblock.c
@@ -82,7 +82,7 @@ cblock_create_pid_file(struct cblock_instance *p)
 	snprintf(pid_buf, sizeof(pid_buf), "%d", p->p_pid);
 	p->p_pid_file_path = strdup(pid_path);
 	p->p_pid_file = open(pid_path, flags, mode);
-	assert(p->p_pid_file != 0);
+	assert(p->p_pid_file != -1);
 	if (p->p_pid_file == -1) {
 		warn("open(%s)", pid_path);
 		return (-1);
@@ -126,6 +126,9 @@ cblock_populate_instance_entries(size_t max_ents)
 	counter = 0;
 	pthread_mutex_lock(&cblock_mutex);
 	TAILQ_FOREACH(p, &pr_head, p_glue) {
+		if (counter >= max_ents) {
+			break;
+		}
 		cur = &vec[counter];
 		strlcpy(cur->p_instance_name, p->p_instance_tag,
 		    sizeof(cur->p_instance_name));
@@ -135,9 +138,6 @@ cblock_populate_instance_entries(size_t max_ents)
 		strlcpy(cur->p_tty_line, p->p_ttyname,
 		    sizeof(cur->p_tty_line));
 		cur->p_start_time = p->p_launch_time;
-		if (counter == max_ents) {
-			break;
-		}
 		switch (p->p_type) {
 		case PRISON_TYPE_BUILD:
 			(void) snprintf(cur->p_type, sizeof(cur->p_type),
@@ -251,14 +251,14 @@ cblock_remove(struct cblock_instance *pi)
 	}
 	CBLOCKD_CBLOCK_DESTROY(pi->p_instance_tag, pi->p_status);
 	cblock_fork_cleanup(pi->p_instance_tag, instance_type, -1, gcfg.c_verbose);
-	assert(pi->p_ttyfd != 0);
+	assert(pi->p_ttyfd != -1);
 	(void) close(pi->p_ttyfd);
 	TAILQ_REMOVE(&pr_head, pi, p_glue);
 	cur = pi->p_ttybuf.t_tot_len;
 	while (cur > 0) {
 		cur = termbuf_remove_oldest(&pi->p_ttybuf);
 	}
-	assert(pi->p_pid_file != 0);
+	assert(pi->p_pid_file != -1);
 	close(pi->p_pid_file);
 	if (unlink(pi->p_pid_file_path) == -1) {
 		warn("unable to remove pidfile");

--- a/src/cblockd/dispatch.c
+++ b/src/cblockd/dispatch.c
@@ -139,7 +139,7 @@ tty_io_queue_loop(void *arg __attribute__((unused)))
 				err(1, "%s: read failed:", __func__);
 			}
 			termbuf_append(&pi->p_ttybuf, buf, cc);
-			if (pi->p_state != STATE_CONNECTED) {
+			if ((pi->p_state & STATE_CONNECTED) == 0) {
 				continue;
 			}
 			len = cc;
@@ -187,7 +187,6 @@ dispatch_signal_instance(int sock)
 		sock_ipc_must_write(sock, &resp, sizeof(resp));
 		return (1);
 	}
-	pthread_mutex_unlock(&cblock_mutex);
 	resp.p_ecode = 0;
 	snprintf(resp.p_errbuf, sizeof(resp.p_errbuf), "OK %d", csi.p_sig);
 	sock_ipc_must_write(sock, &resp, sizeof(resp));

--- a/src/cblockd/main.c
+++ b/src/cblockd/main.c
@@ -208,7 +208,7 @@ daemonize(struct global_params *gcp)
 	int fd;
 
 	if (gcp->c_logfile) {
-		fd = open(gcp->c_logfile, O_WRONLY | O_CREAT, 0700);
+		fd = open(gcp->c_logfile, O_WRONLY | O_CREAT, 0600);
 	} else {
 		gcp->c_logfile = "/dev/null";
 		fd = open("/dev/null", O_WRONLY);
@@ -238,6 +238,7 @@ main(int argc, char *argv [], char *env[])
 	pthread_t thr;
 	char *r;
 
+	zfs_selected = 0;
 	gcfg.c_data_dir = DEFAULT_DATA_DIR;
 	gcfg.global_env = env;
 	gcfg.c_callback = cblock_handle_request;
@@ -275,6 +276,7 @@ main(int argc, char *argv [], char *env[])
 			if (*r != '\0') {
 				errx(1, "invalid TTY buf size: %s", optarg);
 			}
+			break;
 		case '4':
 			gcfg.c_family = PF_INET;
 			break;
@@ -310,7 +312,7 @@ main(int argc, char *argv [], char *env[])
 		}
 	}
 	if (gcfg.c_family != PF_UNSPEC && gcfg.c_name) {
-		errx(1, "-4, -6 and --unix-sock are incompatable");
+		errx(1, "-4, -6 and --unix-sock are incompatible");
 	}
 	if (gcfg.c_underlying_fs == NULL) {
 		errx(1, "must specify underlying file system:\n"


### PR DESCRIPTION
- main.c: add missing break in case 'T', preventing fall-through to case '4'
- main.c: initialize zfs_selected to 0 to avoid uninitialized use with --fuse-unionfs
- main.c: fix log file mode 0700 -> 0600 (execute bit was set)
- main.c: fix typo "incompatable" -> "incompatible"
- cblock.c: fix assert checks from != 0 to != -1 (fd 0 is valid)
- cblock.c: fix off-by-one in cblock_populate_instance_entries, bounds check before write
- dispatch.c: remove double pthread_mutex_unlock in dispatch_signal_instance
- dispatch.c: fix STATE_CONNECTED check to use bitflag test
- build.c: fix wrong variable in waitpid_ignore_intr error check (pid -> rpid)
- build.c: fix undefined behavior in build_get_stage_deps self-referential sprintf